### PR TITLE
Fix invalid port symbol.

### DIFF
--- a/pinknoise/tap_pinknoise.ttl
+++ b/pinknoise/tap_pinknoise.ttl
@@ -59,8 +59,8 @@ lv2:port
 [
     a lv2:InputPort, lv2:ControlPort;
     lv2:index 2;
-    lv2:symbol "Noise Level [dB]";
-    lv2:name "drylevel";
+    lv2:symbol "noiselevel";
+    lv2:name "Noise Level [dB]";
     lv2:default -90;
     lv2:minimum -90;
     lv2:maximum 20;


### PR DESCRIPTION
Most hosts these days explicitly check and throw an error for bad symbols, so this plugin would not load.
